### PR TITLE
Add public changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## [1.4.2] - 2025-05-28
+
+### Changed
+
+- Update extension license terms
+
+### Fixed
+
+- Download and extraction errors when installing pgsql tools service archive ([#56](https://github.com/microsoft/vscode-pgsql/issues/56), [#39](https://github.com/microsoft/vscode-pgsql/issues/39), [#13](https://github.com/microsoft/vscode-pgsql/issues/13s))
+
+## [1.4.1] - 2025-05-15
+
+### Fixed
+
+- Broken relative links in bundled README
+
+## [1.3.1] - 2025-05-15
+
+### Fixed
+
+- Update extension metadata for rendering in VS Code Marketplace
+
+## [1.3.0] - 2025-05-14
+
+_Public preview release._
+
+### Added
+
+- Migrate previous `ms-ossdata.vscode-postgresql` extension settings to the new settings on startup
+
+### Fixed
+
+- Handle cases of unexpected EOF streams in the PostgreSQL Tools Service
+
+## [1.2.0] - 2025-05-08
+
+_Initial release to Marketplace for testing public preview._


### PR DESCRIPTION
Adds a changelog, adhering to https://keepachangelog.com/en/1.1.0/.

This will be updated per-release and the destination for the prompt in VS Code for "viewing release notes" after an upgrade.