### PR TITLE
Update README to include socket connection instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Browse Azure to easily find and connect to your Azure Database for PostgreSQL se
 
 ![Connect to Azure PostgreSQL](img/connect-azure-vid.gif)
 
+#### Connect via Socket
+
+When configuring a connection that uses sockets, provide the folder path that contains the socket file, not the socket file itself.
+
 ### Explore your database
 
 Easily explore your database objects, including tables, views, functions, and more.


### PR DESCRIPTION
Users that connect to a PostgreSQL server via a socket connection should provide the folder path that contains the socket file - not the socket file itself - for the server name.