### PR TITLE
Rename "Metrics Copilot" to "Metrics Intelligence" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Get insights into your PostgreSQL server performance with the Server Dashboard.
 
 ![Server Dashboard](img/metrics-dashboard.gif)
 
-### Metrics Copilot
+### Metrics Intelligence with GitHub Copilot
 
-Get intelligent insights and help with performance and troubleshooting your PostgreSQL database with Copilot.
+Get intelligent insights and help with performance and troubleshooting your PostgreSQL database with integration into Copilot.
 
-![Metrics Copilot](img/metrics-copilot.gif)
+![Metrics Intelligence](img/metrics-copilot.gif)
 
 ### Create a docker PostgreSQL
 


### PR DESCRIPTION
This is to avoid confusion by calling it "Copilot", when it's an integration with GitHub Copilot and not its own Copilot. 