### PR TITLE
Update changelog for PostgreSQL 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ pre-releases and **even** minor version numbers for stable releases.
 Read more about pre-release versioning behavior for extensions in the
 [VS Code documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions).
 
+## [1.30.0] - 2026-08-31
+
+Stable release.
+
+This is the stable release of the features introduced in `1.29.*`. There are no changes since `1.29.1`, but `1.30.0` marks these features as stable for all users.
+
 ## [1.29.0 - 1.29.1] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Quickly connect psql to any of your databases, including Azure Database for Post
 
 ![Run psql](img/psql-connection-vid.gif)
 
-## Oracle to Azure Database for PostgreSQL Schema and Application Conversion (Preview)
+## Oracle to Azure Database for PostgreSQL Schema and Application Conversion
 
 The PostgreSQL extension now includes an intelligent schema conversion feature that helps you migrate Oracle database schemas to Azure Database for PostgreSQL. This AI-powered tool automatically converts Oracle schema objects—including tables, views, stored procedures, functions, and triggers—into PostgreSQL-compatible equivalents. The conversion process uses Azure OpenAI to understand complex Oracle constructs and transform them following PostgreSQL best practices, while validating all converted objects in a scratch database environment to ensure compatibility before deployment. When automatic conversion isn't possible for complex Oracle-specific features, the tool flags these items as Review Tasks that you can resolve with assistance from GitHub Copilot Agents.
 


### PR DESCRIPTION
## Summary

- add the `1.30.0` stable-promotion changelog entry
- remove the Preview label from Oracle schema and application conversion in the README